### PR TITLE
添加ROOT_DOMAIN参数

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,6 +34,7 @@ docker run -d --restart=always --net=host \
 |AKID|阿里云的Access Key ID。[获取阿里云AccessToken](https://usercenter.console.aliyun.com/)|access key id|
 |AKSCT|阿里云的Access Key Secret。|access key secret|
 |DOMAIN|需要更新的域名，可以用“,”隔开。<br>可以指定线路，用“:”分隔线路和域名([线路名说明](https://help.aliyun.com/document_detail/29807.html?spm=a2c4g.11186623.2.14.42405eb4boCsnd))。<br>例如：“baidu.com,telecom:dianxin.baidu.com”。|my.domain.com|
+|ROOT_DOMAIN|以参数DOMAIN为 a.www.example.com 为示例：<br>1.如果参数ROOT_DOMAIN为空，则查询域名为example.com、主机名为”a.www“的解析记录；<br>2.如果参数ROOT_DOMAIN为 www.example.com，则查询域名为www.example.com、主机名为 "a"的解析记录；<br>3.如果参数ROOT_DOMAIN为 a.www.example.com，则查询域名为a.www.example.com、主机名为 "@"的解析记录。|无|
 |REDO|更新间隔，单位秒。建议大于等于TTL/2。|300|
 |TTL|服务器缓存解析记录的时长，单位秒，普通用户最小为600。|600|
 |TIMEZONE|输出日志时的时区，单位小时。|8|
@@ -73,6 +74,7 @@ dotnet aliyun-ddns.dll \
 |u|阿里云的Access Key ID。[获取阿里云AccessToken](https://usercenter.console.aliyun.com/)|access key id|
 |p|阿里云的Access Key Secret。|access key secret|
 |d|需要更新的域名，可以用“,”隔开。<br>可以指定线路，用“:”分隔线路和域名([线路名说明](https://help.aliyun.com/document_detail/29807.html?spm=a2c4g.11186623.2.14.42405eb4boCsnd))。<br>例如：“baidu.com,telecom:dianxin.baidu.com”。|my.domain.com|
+|root-domain|以参数DOMAIN为 a.www.example.com 为示例：<br>1.如果参数ROOT_DOMAIN为空，则查询域名为example.com、主机名为”a.www“的解析记录；<br>2.如果参数ROOT_DOMAIN为 www.example.com，则查询域名为www.example.com、主机名为 "a"的解析记录；<br>3.如果参数ROOT_DOMAIN为 a.www.example.com，则查询域名为a.www.example.com、主机名为 "@"的解析记录。|无|
 |i|更新间隔，单位秒。建议大于等于TTL/2。|300|
 |t|服务器缓存解析记录的时长，单位秒，普通用户最小为600。|600|
 |timezone|输出日志时的时区，单位小时。|8|

--- a/aliyun-ddns/Options.cs
+++ b/aliyun-ddns/Options.cs
@@ -17,6 +17,9 @@ namespace aliyun_ddns
         [Option('d', "domain", Required = false, Default = "my.domain.com", HelpText = "需要更新的域名，可以用“,”隔开。可以指定线路，用“:”分隔线路和域名(线路名说明见https://help.aliyun.com/document_detail/29807.html?spm=a2c4g.11186623.2.14.42405eb4boCsnd)。例如：“baidu.com,telecom:dianxin.baidu.com”。")]
         public string Domain { get; set; } = "my.domain.com";
 
+        [Option("root-domain", Required = false, Default = null, HelpText = "需要更新的主域名")]
+        public string RootDomain { get; set; } = null;
+
         [Option('i', "interval", Required = false, Default = 300, HelpText = "执行域名更新的间隔，单位秒。")]
         public int Redo { get; set; } = 300;
 
@@ -47,7 +50,7 @@ namespace aliyun_ddns
         private static Options _instance = null;
         private static object _instanceLocker = new object();
 
-        public static Options Instance 
+        public static Options Instance
         {
             get
             {
@@ -77,6 +80,7 @@ namespace aliyun_ddns
             Akid = GetEnvironmentVariable("AKID") ?? Akid;
             Aksct = GetEnvironmentVariable("AKSCT") ?? Aksct;
             //ENDPOINT = GetEnvironmentVariable("ENDPOINT") ?? ENDPOINT;
+            RootDomain = GetEnvironmentVariable("ROOT_DOMAIN") ?? RootDomain;
             Domain = GetEnvironmentVariable("DOMAIN") ?? Domain;
             Type = GetEnvironmentVariable("TYPE") ?? Type;
             WebHook = GetEnvironmentVariable("WEBHOOK") ?? WebHook;


### PR DESCRIPTION
通过ROOT_DOMAIN参数指定DescribeSubDomainRecords方法和AddDomainRecord方法的DomainName参数，修复DomainName为二级域名时无法正常使用的问题。如以下issues:
1. [像example.com.cn这样的域名报错](https://github.com/sanjusss/aliyun-ddns/issues/60)
2. [二级域名无法获取记录](https://github.com/sanjusss/aliyun-ddns/issues/64)
