### PR TITLE
删除淘宝 IPv4GetterCreator.cs

### DIFF
--- a/aliyun-ddns/IPGetter/IPv4Getter/IPv4GetterCreator.cs
+++ b/aliyun-ddns/IPGetter/IPv4Getter/IPv4GetterCreator.cs
@@ -12,7 +12,6 @@ namespace aliyun_ddns.IPGetter.IPv4Getter
                 new CommonIPv4Getter("test-ipv6.com接口", "https://ipv4.lookup.test-ipv6.com/ip/", 100),
                 //new CommonIPv4Getter("ipip.net接口", "http://myip.ipip.net/"),
                 new CommonIPv4Getter("ip-api.com接口", "http://ip-api.com/json/?fields=query", 100),
-                new CommonIPv4Getter("淘宝接口", "http://ip.taobao.com/service/getIpInfo.php?ip=myip"),
                 new CommonIPv4Getter("3322接口", "http://ip.3322.net/"),
             };
 


### PR DESCRIPTION
淘宝 API 404
![image](https://github.com/sanjusss/aliyun-ddns/assets/7604648/361deab9-b814-49df-a173-b6107a95730c)
